### PR TITLE
Add avatar slash commands and adjust inquiry messaging

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,6 +58,20 @@ async def on_member_remove(member: discord.Member):
         
         
         
+@bot.event
+async def on_member_join(member: discord.Member):
+    channel = bot.get_channel(1384416986926288909)
+    if not channel:
+        print("❌ 입장 로그 채널을 찾을 수 없습니다.")
+        return
+
+    display_name = member.global_name or member.display_name
+    await channel.send(
+        f"📥 {member.mention}({display_name}) 님이 서버에 들어왔습니다."
+    )
+
+
+
 register_slash_commands(bot)
 register_game_commands(bot)
 bot.run(get_token())

--- a/slash_command.py
+++ b/slash_command.py
@@ -24,7 +24,62 @@ tts_text_channel_id: int | None = None  # ✅ 읽을 텍스트 채널 ID 저장
 
 # 메인 봇 객체가 있는 곳에서 불러올 예정이므로 Cog 사용 X
 def register_slash_commands(bot: commands.Bot):
-    
+
+    async def send_avatar(
+        ctx: discord.ApplicationContext,
+        member: discord.Member,
+        size: int = 1024,
+    ) -> None:
+        avatar_url = member.display_avatar.replace(size=size).url
+        embed = discord.Embed(
+            title=f"🖼️ {member.display_name} 님의 프로필 사진",
+            description="이미지 크기는 옵션에서 조절할 수 있어요!",
+            color=discord.Color.blurple(),
+        )
+        embed.add_field(name="요청한 크기", value=f"{size}px", inline=True)
+        embed.set_image(url=avatar_url)
+        await ctx.respond(content=f"{member.mention} 님의 프로필 사진입니다.", embed=embed)
+
+    @bot.slash_command(
+        name="프로필사진",
+        description="선택한 멤버의 프로필 사진을 크게 보여줍니다.",
+    )
+    async def show_avatar(
+        ctx: discord.ApplicationContext,
+        member: discord.Member,
+        size: discord.Option(  # type: ignore
+            int,
+            "가져올 이미지 크기",
+            choices=[
+                discord.OptionChoice(name="256px", value=256),
+                discord.OptionChoice(name="512px", value=512),
+                discord.OptionChoice(name="1024px", value=1024),
+            ],
+            default=1024,
+        ),
+    ):
+        await send_avatar(ctx, member, size)
+
+    @bot.slash_command(
+        name="프사",
+        description="선택한 멤버의 프로필 사진을 크게 보여줍니다.",
+    )
+    async def show_avatar_shortcut(
+        ctx: discord.ApplicationContext,
+        member: discord.Member,
+        size: discord.Option(  # type: ignore
+            int,
+            "가져올 이미지 크기",
+            choices=[
+                discord.OptionChoice(name="256px", value=256),
+                discord.OptionChoice(name="512px", value=512),
+                discord.OptionChoice(name="1024px", value=1024),
+            ],
+            default=1024,
+        ),
+    ):
+        await send_avatar(ctx, member, size)
+
     @bot.slash_command(name="프로필", description="해당 유저의 프로필을 확인합니다.")
     async def show_profile(
         ctx: discord.ApplicationContext,

--- a/ticket.py
+++ b/ticket.py
@@ -34,9 +34,9 @@ class InquiryTypeView(View):
     async def report_button(self, button: Button, interaction: discord.Interaction):
         await self.setup_ticket(interaction, "사건 신고")
 
-    @discord.ui.button(label="📘 규칙 문의", style=discord.ButtonStyle.primary)
+    @discord.ui.button(label="📘 문의&건의", style=discord.ButtonStyle.primary)
     async def rule_button(self, button: Button, interaction: discord.Interaction):
-        await self.setup_ticket(interaction, "규칙 문의")
+        await self.setup_ticket(interaction, "문의&건의")
 
     @discord.ui.button(label="💡 기능 문의", style=discord.ButtonStyle.success)
     async def feature_button(self, button: Button, interaction: discord.Interaction):
@@ -183,8 +183,8 @@ async def send_ticket_message(bot: commands.Bot):
             "무엇을 도와드릴까요?\n"
             "아래에서 문의 유형을 선택해주세요!\n\n"
             "📢 **사건 신고**: 서버 내 문제 상황을 알려주세요.\n"
-            "📘 **규칙 문의**: 서버 규칙에 대한 문의가 있어요.\n"
-            "💡 **기능 문의**: 디스코드 봇/기능 관련 건의사항을 남겨주세요."
+            "📘 **문의&건의**: 규칙 문의나 건의사항을 남겨주세요.\n"
+            "💡 **기능 문의**: 디스코드 봇/기능 관련 문의를 남겨주세요."
         ),
         color=discord.Color.blue()
     )


### PR DESCRIPTION
## Summary
- add `/프로필사진` and `/프사` commands so members can share avatars at selectable sizes
- log member join events in the existing departure log channel for better visibility
- rename the inquiry button to "문의&건의" and update the ticket embed description accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de926e71848329a96bda58970230df