### PR TITLE
Update member profile prompts and welcomes

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,9 +53,20 @@ def format_user(member: discord.Member, with_mention: bool = True) -> str:
 
 @bot.event
 async def on_member_join(member: discord.Member):
-    channel = bot.get_channel(1411965966233112647)
-    if channel:
-        await channel.send(f"📥 {format_user(member, with_mention=True)} 님 반가워요!👋\n[프로필설정] 채널에 가셔서 별명 변경과 멤버 등록을 하시고\n자유로운 활동을 시작해보세요🐹")
+    welcome_message = (
+        f"📥 {format_user(member, with_mention=False)} 님 반가워요!👋\n"
+        "[프로필설정] 채널에 가셔서 별명 변경과 멤버 등록을 하시고\n"
+        "자유로운 활동을 시작해보세요🐹"
+    )
+
+    try:
+        await member.send(welcome_message)
+    except discord.Forbidden:
+        pass
+
+    log_channel = bot.get_channel(1384416986926288909)
+    if log_channel:
+        await log_channel.send(f"📥 {format_user(member, with_mention=False)} 님이 서버에 입장했습니다.")
 
 @bot.event
 async def on_member_remove(member: discord.Member):

--- a/profile_setting.py
+++ b/profile_setting.py
@@ -241,76 +241,39 @@ class IntroModal(discord.ui.Modal):
         self.new = new
         self.existing_data = existing_data or {}
 
-        
-        self.mbti = discord.ui.InputText(
-            label="MBTI (16종류, 영문 대문자 or 소문자)",
-            placeholder="예: INFP 또는 infp, 미공개",
-            required=True,
-            max_length=4,
-            value=self.existing_data.get("mbti", None)
-        )
         self.referral = discord.ui.InputText(
-            label="가입 경로 (지인 소개 시 닉네임 포함)",
-            placeholder="예: 디스보드, 친구추천(별명)",
+            label="가입 경로 & 목적",
+            placeholder="예: 디스보드, 친구추천(별명) / 친목, 게임 파티 구인", 
             required=True,
             value=self.existing_data.get("referral", None)
         )
-        self.bio = discord.ui.InputText(
-            label="간단 한줄 자기소개",
-            placeholder="예: 다양한 게임을 좋아하는 사람입니다!",
-            max_length=200,
-            required=True,
-            value=self.existing_data.get("bio", None)
-        )
 
-        self.add_item(self.mbti)
         self.add_item(self.referral)
-        self.add_item(self.bio)
 
     async def callback(self, interaction: discord.Interaction):
-        mbti_value = self.mbti.value.strip()
         referral = self.referral.value.strip()
-        
-        bio_value = self.bio.value.strip()
-
-        valid_mbti = {
-            'intj','intp','entj','entp','infj','infp','enfj','enfp',
-            'istj','isfj','estj','esfj','istp','isfp','estp','esfp', '미공개'
-        }
-
-        if mbti_value.lower() not in valid_mbti:
-            await interaction.response.send_message(
-                f"❌ `{mbti_value}` 는 올바른 MBTI 값이 아니에요!",
-                ephemeral=True, delete_after=5
-            )
-            return
-        
-        mbti_value = mbti_value.upper() if mbti_value.lower() != "미공개" else "미공개"
-        
 
         await interaction.response.send_message(
             embed=discord.Embed(
                 title=f"📝 {self.nickname} 프로필 설정 (2/2)",
-                description="✅ 기본 프로필 설정이 완료되었어요!\n\n🎮 마지막으로 게임 관련 질문들 몇 가지만 더 여쭤볼게요!",
+                description="✅ 기본 프로필 설정이 완료되었어요!\n\n🎮 마지막으로 게임 관련 정보를 알려주세요!",
                 color=discord.Color.blurple()
             ),
             view=GameModalConfirmView(
                 nickname=self.nickname,
                 user_id=self.user_id,
-                mbti=mbti_value,
                 referral=referral,
                 new=self.new,
-                existing_data={**self.existing_data, "bio": bio_value}
+                existing_data=self.existing_data
             ),
             ephemeral=True
         )
         
 class GameModalConfirmView(discord.ui.View):
-    def __init__(self, nickname, user_id, mbti, referral, new, existing_data):
+    def __init__(self, nickname, user_id, referral, new, existing_data):
         super().__init__(timeout=300)  # 5분 타임아웃
         self.nickname = nickname
         self.user_id = user_id
-        self.mbti = mbti
         self.referral = referral
         self.new = new
         self.existing_data = existing_data
@@ -320,7 +283,6 @@ class GameModalConfirmView(discord.ui.View):
         await interaction.response.send_modal(GameModal(
             nickname=self.nickname,
             user_id=self.user_id,
-            mbti=self.mbti,
             referral=self.referral,
             new=self.new,
             existing_data=self.existing_data
@@ -328,62 +290,39 @@ class GameModalConfirmView(discord.ui.View):
 
 
 class GameModal(discord.ui.Modal):
-    def __init__(self, nickname, user_id, mbti=None, referral=None, new=False, existing_data=None):
+    def __init__(self, nickname, user_id, referral=None, new=False, existing_data=None):
         super().__init__(title=f"📝 {nickname} 프로필 설정 (2/2)", custom_id=f"profile_modal_step2_{user_id}")
         self.nickname = nickname
         self.user_id = user_id
-        self.mbti = mbti
         self.referral = referral
         self.new = new
         self.existing_data = existing_data or {}
-        
+
         self.code = discord.ui.InputText(
             label="STEAM 친구코드",
-            placeholder="예: 숫자 또는 미공개",
-            required=True,
+            placeholder="예: 비작성시 미공개 처리",
+            required=False,
             value=self.existing_data.get("code", None)
         )
 
         self.games = discord.ui.InputText(
-            label="자주 하는 게임",
-            placeholder="예: 리그오브레전드, 오버워치",
-            max_length=100,
+            label="자주 하는 게임 & 선호 장르",
+            placeholder="예: 리그오브레전드, 오버워치 / AOS, FPS",
             required=False,
             value=self.existing_data.get("favorite_games", None)
-        )
-        self.wanted = discord.ui.InputText(
-            label="하고 싶은 게임",
-            placeholder="예: 세븐데이즈투다이, 마인크래프트",
-            max_length=100,
-            required=False,
-            value=self.existing_data.get("wanted_games", None)
         )
 
         self.add_item(self.code)
         self.add_item(self.games)
-        self.add_item(self.wanted)
 
     async def callback(self, interaction: discord.Interaction):
-        mbti_value = self.mbti.upper() if self.mbti.lower() != "미공개" else "미공개"
-        
         code_value = self.code.value.strip()
-        
-        if code_value.lower() != "미공개" and not code_value.isdigit():
-            await interaction.response.send_message(
-                f"❌ `{code_value}` 는 올바른 스팀 친구코드가 아니에요! (숫자만 입력하거나 '미공개'를 입력해주세요)",
-                ephemeral=True, delete_after=5
-            )
-            return
-        
         code_value = code_value or "미공개"
 
         save_profile(
             user_id=self.user_id,
-            mbti=mbti_value,
             favorite_games=self.games.value.strip(),
-            wanted_games=self.wanted.value.strip(),
             referral=self.referral,
-            bio=self.existing_data.get("bio", ""),  # bio는 이전 모달에서 받음
             code=code_value
         )
 
@@ -417,12 +356,9 @@ class GameModal(discord.ui.Modal):
                     description=f"{interaction.user.mention} 님의 프로필입니다:",
                     color=discord.Color.green()
                 )
-                embed.add_field(name="MBTI", value=f"**{mbti_value}**", inline=True)
                 embed.add_field(name="스팀 친구 코드", value=f"**{code_value}**", inline=True)
-                embed.add_field(name="자주 하는 게임", value=f"**{self.games.value.strip() or '없음'}**", inline=False)
-                embed.add_field(name="하고 싶은 게임", value=f"**{self.wanted.value.strip() or '없음'}**", inline=False)
-                embed.add_field(name="가입 경로", value=f"**{self.referral}**", inline=False)
-                embed.add_field(name="한줄 소개", value=f"``{self.existing_data.get('bio', '')}``", inline=False)
+                embed.add_field(name="자주 하는 게임 & 선호 장르", value=f"**{self.games.value.strip() or '없음'}**", inline=False)
+                embed.add_field(name="가입 경로 & 목적", value=f"**{self.referral or '없음'}**", inline=False)
                 embed.set_thumbnail(url=interaction.user.display_avatar.url)
 
-                await channel.send(content=f"🎊 새로운 맴버 **{interaction.user.mention}** 님이 들어오셨어요!", embed=embed)
+                await channel.send(content=f"🌟 새로운 멤버 **{interaction.user.mention}** 님의 프로필이에요.", embed=embed)

--- a/slash_command.py
+++ b/slash_command.py
@@ -94,23 +94,20 @@ def register_slash_commands(bot: commands.Bot):
             title=f"📘 {member.display_name} 님의 프로필",
             color=discord.Color.blurple()
         )
-        mbti_value = profile['mbti']
-        if mbti_value and mbti_value.lower() != "미공개":
-            mbti_display = mbti_value.upper()
-        else:
-            mbti_display = mbti_value or "미공개"
 
-        embed.add_field(name="MBTI", value=f"**{mbti_display}**", inline=False)
         embed.add_field(name="스팀 친구 코드", value=f"**{profile['code'] or '미공개'}**", inline=True)
-        embed.add_field(name="자주 하는 게임", value=f"**{profile['favorite_games'] or '없음'}**", inline=False)
-        embed.add_field(name="하고 싶은 게임", value=f"**{profile['wanted_games'] or '없음'}**", inline=False)
-        embed.add_field(name="가입 경로", value=f"**{profile['referral']}**", inline=False)
-        embed.add_field(name="한줄 소개", value=f"``{profile['bio']}``", inline=False)
-        
+        embed.add_field(
+            name="자주 하는 게임 & 선호 장르",
+            value=f"**{profile['favorite_games'] or '없음'}**",
+            inline=False,
+        )
+        embed.add_field(
+            name="가입 경로 & 목적",
+            value=f"**{profile['referral'] or '없음'}**",
+            inline=False,
+        )
 
-        # embed.set_footer(text="프로필은 언제든지 수정할 수 있어요 ✨")
-
-        await ctx.respond(embed=embed)
+        await ctx.respond(content=f"🔍 {member.mention} 님의 프로필이에요.", embed=embed)
         
     
     @bot.slash_command(

--- a/utils/function.py
+++ b/utils/function.py
@@ -52,13 +52,28 @@ def get_token():
     finally:
         conn.close()
 
-def save_profile(user_id: int, mbti: str, favorite_games: str, wanted_games: str, referral: str, bio: str, code: str):
+def save_profile(
+    user_id: int,
+    favorite_games: str,
+    referral: str,
+    code: str,
+    mbti: str | None = None,
+    wanted_games: str | None = None,
+    bio: str | None = None,
+):
     """
     사용자 프로필 저장 또는 업데이트
     """
     try:
         conn = get_connection()
         cursor = conn.cursor()
+
+        mbti_value = (mbti or "").strip()
+        favorite_games_value = (favorite_games or "").strip()
+        wanted_games_value = (wanted_games or "").strip()
+        referral_value = (referral or "").strip()
+        bio_value = (bio or "").strip()
+        code_value = (code or "미공개").strip()
 
         cursor.execute("""
             INSERT INTO user_profiles (user_id, mbti, favorite_games, wanted_games, referral, bio, code)
@@ -71,8 +86,16 @@ def save_profile(user_id: int, mbti: str, favorite_games: str, wanted_games: str
                 referral = EXCLUDED.referral,
                 bio = EXCLUDED.bio,
                 code = EXCLUDED.code;
-        """, (user_id, mbti.strip(), favorite_games.strip(), wanted_games.strip(), referral.strip(), bio.strip(),code.strip()))
-        
+        """, (
+            user_id,
+            mbti_value,
+            favorite_games_value,
+            wanted_games_value,
+            referral_value,
+            bio_value,
+            code_value,
+        ))
+
         cursor.execute("INSERT INTO voice_leaderboard (user_id) VALUES (%s) ON CONFLICT DO NOTHING;", (user_id,))
         conn.commit()
         return True


### PR DESCRIPTION
## Summary
- simplify member profile questions to focus on friend code, favorite games and join purpose while removing MBTI/intro prompts
- update admin and slash-command profile displays with the new fields and relaxed Steam friend code handling
- send welcome guidance via DM, log joins to the log channel, and keep profile registration announcements consistent

## Testing
- python -m py_compile main.py profile_setting.py slash_command.py utils/function.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e90c96758832992b0a12e29ad1ba5)